### PR TITLE
Add --web-host option to input server for external access

### DIFF
--- a/src/bin/input_server.rs
+++ b/src/bin/input_server.rs
@@ -23,6 +23,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .default_value("8001"),
         )
         .arg(
+            Arg::new("web-host")
+                .long("web-host")
+                .value_name("HOST")
+                .help("Web server hostname")
+                .default_value("127.0.0.1"),
+        )
+        .arg(
             Arg::new("web-port")
                 .long("web-port")
                 .value_name("PORT")
@@ -65,6 +72,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let network_host = matches.get_one::<String>("network-host").unwrap().clone();
     let network_port: u16 = matches.get_one::<String>("network-port").unwrap().parse()?;
+    let web_host = matches.get_one::<String>("web-host").unwrap().clone();
     let web_port: u16 = matches.get_one::<String>("web-port").unwrap().parse()?;
     let websocket_port: u16 = matches
         .get_one::<String>("websocket-port")
@@ -77,8 +85,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("🚀 Starting InputServer");
     println!("   Neural Network: {}:{}", network_host, network_port);
-    println!("   Web Interface: http://127.0.0.1:{}", web_port);
-    println!("   WebSocket: ws://127.0.0.1:{}", websocket_port);
+    println!("   Web Interface: http://{}:{}", web_host, web_port);
+    println!("   WebSocket: ws://{}:{}", web_host, websocket_port);
     println!("   Input Size: {}", input_size);
     println!("   TLS: {}", if use_tls { "Enabled" } else { "Disabled" });
 
@@ -94,7 +102,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create InputServer configuration
     let config = InputServerConfig {
-        web_address: "127.0.0.1".to_string(),
+        web_address: web_host,
         web_port,
         websocket_port,
         neural_networks: vec![neural_network],

--- a/test_input_server.sh
+++ b/test_input_server.sh
@@ -35,8 +35,9 @@ echo "🌐 Starting InputServer..."
 cargo run --bin input_server -- \
     --network-host 127.0.0.1 \
     --network-port 8001 \
-    --web-port 3000 \
-    --websocket-port 3001 \
+    --web-host 0.0.0.0 \
+    --web-port 12000 \
+    --websocket-port 12001 \
     --input-size 4 &
 INPUT_SERVER_PID=$!
 
@@ -47,11 +48,11 @@ echo ""
 echo "🎉 System is running!"
 echo "================================"
 echo "📡 Neural Network Server: 127.0.0.1:8001"
-echo "🌐 Web Interface: http://127.0.0.1:3000"
-echo "🔌 WebSocket: ws://127.0.0.1:3001"
+echo "🌐 Web Interface: http://127.0.0.1:12000"
+echo "🔌 WebSocket: ws://127.0.0.1:12001"
 echo ""
 echo "📋 Instructions:"
-echo "1. Open http://127.0.0.1:3000 in your browser"
+echo "1. Open http://127.0.0.1:12000 in your browser"
 echo "2. Use the sliders to adjust input values"
 echo "3. Click 'Send to Network' to transmit data"
 echo "4. Watch the console for neural network activity"


### PR DESCRIPTION
## Summary

This PR adds a `--web-host` command line option to the input server binary, enabling it to bind to external interfaces (like `0.0.0.0`) for accessibility from external environments.

## Changes Made

### Input Server Binary (`src/bin/input_server.rs`)
- ✅ Added `--web-host` command line argument with default value `127.0.0.1`
- ✅ Updated configuration to use the specified web host instead of hardcoded `127.0.0.1`
- ✅ Updated help text and status output to reflect the configurable host
- ✅ Maintains backward compatibility with existing usage

### Test Script (`test_input_server.sh`)
- ✅ Updated to use `--web-host 0.0.0.0` for external environment compatibility
- ✅ Updated port configuration from 3000/3001 to 12000/12001 for external runtime

## Problem Solved

Previously, the input server was hardcoded to bind to `127.0.0.1`, which prevented access from external URLs in containerized or remote environments. This change allows the server to be accessible from external interfaces while maintaining security by defaulting to localhost.

## Testing

- ✅ All existing unit tests pass (`cargo test`)
- ✅ Integration example tests pass (`cargo run --example simple_io_test`)
- ✅ Manual testing confirms web interface loads successfully
- ✅ Neural network server connection works correctly
- ✅ HTTP server binds to specified host and port

## Backward Compatibility

- ✅ Default behavior unchanged (still binds to `127.0.0.1` by default)
- ✅ Existing command line arguments remain the same
- ✅ No breaking changes to the API or configuration

## Usage

```bash
# Default behavior (localhost only)
cargo run --bin input_server

# External access
cargo run --bin input_server -- --web-host 0.0.0.0

# Custom host
cargo run --bin input_server -- --web-host 192.168.1.100
```

This change enables the neural network input server to work properly in external runtime environments while maintaining security and backward compatibility.

@benwah can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b7e0c1466b4a4278a1773f138440942d)