### PR TITLE
Fix input size mismatch in InputNode implementation

### DIFF
--- a/examples/input_size_test.rs
+++ b/examples/input_size_test.rs
@@ -1,0 +1,89 @@
+use neural_network::{InputNode, IoNodeConfig};
+use std::time::Duration;
+use tokio::time::sleep;
+use uuid::Uuid;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Test with matching input size
+    println!("Test 1: Matching input size (should succeed)");
+    let config = IoNodeConfig {
+        node_id: Uuid::new_v4(),
+        name: "TestInputNode".to_string(),
+        listen_address: "127.0.0.1".to_string(),
+        listen_port: 0, // Let the OS assign a port
+        target_address: None,
+        target_port: None,
+        use_tls: false,
+        cert_path: None,
+        key_path: None,
+        data_transformation: None,
+        input_size: 4,
+    };
+    
+    let (input_node, _) = InputNode::new(config);
+    
+    // This should succeed
+    match input_node.send_data(vec![0.1, 0.2, 0.3, 0.4]).await {
+        Ok(_) => println!("✅ Test 1 passed: Successfully sent data with matching input size"),
+        Err(e) => println!("❌ Test 1 failed: {}", e),
+    }
+    
+    // Wait a bit
+    sleep(Duration::from_millis(500)).await;
+    
+    // Test with mismatched input size
+    println!("\nTest 2: Mismatched input size (should fail)");
+    let config = IoNodeConfig {
+        node_id: Uuid::new_v4(),
+        name: "TestInputNode".to_string(),
+        listen_address: "127.0.0.1".to_string(),
+        listen_port: 0, // Let the OS assign a port
+        target_address: None,
+        target_port: None,
+        use_tls: false,
+        cert_path: None,
+        key_path: None,
+        data_transformation: None,
+        input_size: 4,
+    };
+    
+    let (input_node, _) = InputNode::new(config);
+    
+    // This should fail with an input size mismatch error
+    match input_node.send_data(vec![0.1, 0.2, 0.3, 0.4, 0.5]).await {
+        Ok(_) => println!("❌ Test 2 failed: Should have rejected mismatched input size"),
+        Err(e) => println!("✅ Test 2 passed: Correctly rejected mismatched input size: {}", e),
+    }
+    
+    // Test with different input size
+    println!("\nTest 3: Different input size configuration (should succeed)");
+    let config = IoNodeConfig {
+        node_id: Uuid::new_v4(),
+        name: "TestInputNode".to_string(),
+        listen_address: "127.0.0.1".to_string(),
+        listen_port: 0, // Let the OS assign a port
+        target_address: None,
+        target_port: None,
+        use_tls: false,
+        cert_path: None,
+        key_path: None,
+        data_transformation: None,
+        input_size: 16,
+    };
+    
+    let (input_node, _) = InputNode::new(config);
+    
+    // Create a vector with 16 elements
+    let data: Vec<f64> = (0..16).map(|i| i as f64 * 0.1).collect();
+    
+    // This should succeed
+    match input_node.send_data(data).await {
+        Ok(_) => println!("✅ Test 3 passed: Successfully sent data with input_size=16"),
+        Err(e) => println!("❌ Test 3 failed: {}", e),
+    }
+    
+    println!("\nAll tests completed!");
+    
+    Ok(())
+}


### PR DESCRIPTION
## Problem
When sending data to the neural network instance with an input server, an input size mismatch error occurs:
```
assertion `left == right` failed: Input size mismatch
  left: 16
 right: 4
```

This happens because the InputNode creates a dummy neural network with a fixed input size of 4, regardless of the configured input size.

## Solution
This PR implements a cleaner solution that:

1. Makes `input_size` a required parameter in `IoNodeConfig` (it was already required but not properly validated)
2. Validates input data against the configured input size before sending
3. Adds a direct message sending capability to bypass neural network processing entirely
4. Implements a proper peer lookup by address and port in the `DistributedNetwork` class

## Changes
- Updated `InputNode::send_data` method to validate input size against the configured size
- Added `find_peer_by_address` method to `DistributedNetwork` to locate peers by address/port
- Simplified the `send_data` method to attempt direct message sending to peers
- Added a test example to verify the input size validation works correctly

## Testing
Created a new example `input_size_test.rs` that tests:
1. Sending data with matching input size (succeeds)
2. Sending data with mismatched input size (fails with appropriate error)
3. Sending data with a different input size configuration (succeeds)

All tests pass successfully.

## Additional Notes
This change eliminates the need for a dummy neural network in the InputNode, making the code cleaner and more efficient. It also properly validates input sizes, preventing the assertion failure that was occurring.

@benwah can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d89db73a244e4e52ae00b75861be7d0c)