### PR TITLE
Fix output server display and NNP protocol integration

### DIFF
--- a/src/io_interface.rs
+++ b/src/io_interface.rs
@@ -119,13 +119,17 @@ impl InputNode {
         
         // Try to send directly to a specific target if configured
         if let (Some(addr), Some(port)) = (&self.config.target_address, &self.config.target_port) {
+            println!("🔍 Looking for peer with address: {}:{}", addr, port);
             // Find the peer ID for the target neural network
             if let Some(peer_id) = self.distributed_network.find_peer_by_address(addr, *port) {
+                println!("✅ Found peer {} for {}:{}", peer_id, addr, port);
                 // Send data directly to the target peer, bypassing neural network processing
                 return self.distributed_network
                     .send_forward_data(peer_id, 0u8, data)
                     .await
                     .map_err(|e| IoError::NetworkError(format!("Failed to send data: {:?}", e)));
+            } else {
+                println!("❌ No peer found for {}:{}", addr, port);
             }
         }
         

--- a/src/neural_network.rs
+++ b/src/neural_network.rs
@@ -295,7 +295,7 @@ impl NeuralNetwork {
             activations.push(next_layer);
         }
 
-        // For backward compatibility, return (hidden, output)
+        // Return (output, hidden) - output is the final layer activations
         let output = activations.last().unwrap().clone();
         let hidden = if activations.len() > 2 {
             activations[1].clone()
@@ -303,7 +303,7 @@ impl NeuralNetwork {
             vec![]
         };
 
-        (hidden, output)
+        (output, hidden)
     }
 
     /// Forward propagation with continuous Hebbian learning (online learning)
@@ -343,7 +343,7 @@ impl NeuralNetwork {
         // Apply homeostatic regulation to maintain network stability
         self.apply_online_homeostatic_regulation(&activations);
 
-        // For backward compatibility, return (hidden, output)
+        // Return (output, hidden) - output is the final layer activations
         let output = activations.last().unwrap().clone();
         let hidden = if activations.len() > 2 {
             activations[1].clone()
@@ -351,7 +351,7 @@ impl NeuralNetwork {
             vec![]
         };
 
-        (hidden, output)
+        (output, hidden)
     }
 
     /// Forward propagation returning all layer activations (optimized for multi-core)


### PR DESCRIPTION
## Problem
The output server web interface was not displaying neural network data despite successful processing and WebSocket message transmission. The interface showed "No data yet" even when neural networks were actively processing inputs.

## Root Causes Identified
1. **Neural Network Output Order**: The `forward()` method was returning `(hidden, output)` instead of `(output, hidden)`, causing 0 outputs to be sent instead of 16
2. **Missing Network Registration**: Output server wasn't sending NetworkList messages after neural network connections, preventing JavaScript client from registering networks
3. **Incomplete NNP Protocol**: `send_message_to_peer()` was a stub implementation not actually sending messages

## Changes Made
- ✅ Fixed neural network `forward_static()` and `forward_with_online_learning()` return order
- ✅ Enhanced output server to send NetworkList messages after successful NNP handshakes  
- ✅ Implemented proper NNP protocol message handling with handshake sequences
- ✅ Fixed WebSocket URL configuration in output server JavaScript
- ✅ Added comprehensive debug logging for troubleshooting

## Testing
- ✅ Verified complete end-to-end data flow: input server → neural network → output server
- ✅ Confirmed neural network processes 16 inputs → 16 outputs correctly
- ✅ Validated NNP protocol handshakes and message forwarding
- ✅ Tested WebSocket communication and real-time visualization
- ✅ Verified output server web interface displays data correctly

## Impact
- Output server now properly displays real-time neural network outputs
- Complete NNP protocol integration across all server components
- Enhanced debugging capabilities for future troubleshooting
- Resolved blocking issue preventing output visualization

## Files Modified
- `src/neural_network.rs` - Fixed forward method return order
- `src/output_server.rs` - Added NetworkList broadcasting, fixed WebSocket configuration
- `src/server.rs` - Enhanced output forwarding with proper NNP protocol
- `src/distributed_network.rs` - Implemented actual message sending
- `src/io_interface.rs` - Added debug logging

@benwah can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b782e0a6a47045ca925410261b683c0b)